### PR TITLE
Do not append .local to domain name. Fixes schmengler#9

### DIFF
--- a/puphpet/templates/allinone/config.yaml
+++ b/puphpet/templates/allinone/config.yaml
@@ -126,7 +126,7 @@ apache:
             directories:
                 dynausnskjm4:
                     provider: directory
-                    path: /var/www/{DOMAIN}.local
+                    path: /var/www/{DOMAIN}
                     options:
                         - Indexes
                         - FollowSymlinks
@@ -158,7 +158,7 @@ apache:
             directories:
                 dynausnskjm4:
                     provider: directory
-                    path: /var/www/{DOMAIN}.local
+                    path: /var/www/{DOMAIN}
                     options:
                         - Indexes
                         - FollowSymlinks

--- a/puphpet/templates/modman/config.yaml
+++ b/puphpet/templates/modman/config.yaml
@@ -152,7 +152,7 @@ apache:
             directories:
                 dynausnskjm4:
                     provider: directory
-                    path: /var/www/{DOMAIN}.local
+                    path: /var/www/{DOMAIN}
                     options:
                         - Indexes
                         - FollowSymlinks
@@ -184,7 +184,7 @@ apache:
             directories:
                 dynausnskjm4:
                     provider: directory
-                    path: /var/www/{DOMAIN}.local
+                    path: /var/www/{DOMAIN}
                     options:
                         - Indexes
                         - FollowSymlinks

--- a/puphpet/templates/nginx/config.yaml
+++ b/puphpet/templates/nginx/config.yaml
@@ -148,7 +148,7 @@ apache:
             directories:
                 avd_fqwlfk8hr7fm:
                     provider: directory
-                    path: /var/www/{DOMAIN}.local
+                    path: /var/www/{DOMAIN}
                     options:
                         - Indexes
                         - FollowSymlinks


### PR DESCRIPTION
The reason, that I just saw the PHP source was, that I entered the FQDN (so with .local) as the ```./up``` script asked me for a local domain name, but the puphpet config appended a second .local to it, resulting in an Apache directive like that:
```
<Directory "/var/www/project.magento.local.local">
```

Since not everybody wants to use the .local domain, the puppet templates should not enforce it.
As an alternative and if you still want to support the .local best practice, you could additionally modify the ```./up``` script, so if somebody enters just a hostname without any dots .local becomes appended.
Or otherwise you could just change the help message, saying that .local becomes always appended ;-)