### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Autodetect text files
+* text=auto
+
+# Force the following files to have unix eols, so Windows does not break them
+*.sh text eol=lf
+up text eol=lf


### PR DESCRIPTION
This will prevent Windows from breaking the line endings that are required for cygwin.