### PR TITLE
fix_broken_curlrequests

### DIFF
--- a/puphpet/puppet/modules/puphpet/manifests/php/composer.pp
+++ b/puphpet/puppet/modules/puphpet/manifests/php/composer.pp
@@ -31,7 +31,7 @@ class puphpet::php::composer (
   class { '::composer':
     target_dir      => '/usr/local/bin',
     composer_file   => 'composer',
-    download_method => 'curl',
+    download_method => 'wget',
     logoutput       => false,
     tmp_path        => '/tmp',
     php_package     => $php_package,


### PR DESCRIPTION
with current vagrant 1.8.1 and box_type 2.0 composer.pp failes. Scheinbar mögen die composer.org jungs curl requests von windows mit cygwin nicht.

Ein wget tuts. 
